### PR TITLE
feat: Enable coinbase pay via statsig

### DIFF
--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -35,7 +35,6 @@ import {
   selectFiatConnectQuoteLoadingSelector,
 } from 'src/fiatconnect/selectors'
 import { fetchFiatConnectQuotes } from 'src/fiatconnect/slice'
-import { readOnceFromFirebase } from 'src/firebase/firebase'
 import i18n from 'src/i18n'
 import {
   getDefaultLocalCurrencyCode,
@@ -111,8 +110,9 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
 
   const { t } = useTranslation()
   const coinbasePayEnabled = useSelector(coinbasePayEnabledSelector)
-  const appIdResponse = useAsync(async () => readOnceFromFirebase('coinbasePay/appId'), [])
-  const appId = appIdResponse.result
+  const appId = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.COINBASE_PAY_APP_ID]
+  ).appId
 
   useEffect(() => {
     if (FETCH_FIATCONNECT_QUOTES) {
@@ -201,10 +201,10 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
   )
   const coinbasePayVisible =
     flow === CICOFlow.CashIn &&
-    coinbaseProvider &&
+    !!coinbaseProvider &&
     !coinbaseProvider.restricted &&
     coinbasePayEnabled &&
-    appId
+    !!appId
 
   const anyProviders =
     normalizedQuotes.length ||

--- a/src/navigator/NavigatorWrapper.test.tsx
+++ b/src/navigator/NavigatorWrapper.test.tsx
@@ -1,4 +1,3 @@
-import dynamicLinks from '@react-native-firebase/dynamic-links'
 import { render, waitFor } from '@testing-library/react-native'
 import CleverTap from 'clevertap-react-native'
 import * as React from 'react'
@@ -55,10 +54,8 @@ describe('NavigatorWrapper', () => {
 
     await waitFor(() => expect(CleverTap.addListener).toHaveBeenCalled())
     expect(Linking.addEventListener).toHaveBeenCalled()
-    expect(dynamicLinks().onLink).toHaveBeenCalled()
     expect(CleverTap.getInitialUrl).toHaveBeenCalled()
     expect(Linking.getInitialURL).toHaveBeenCalled()
-    expect(dynamicLinks().getInitialLink).toHaveBeenCalled()
     expect(queryByText('appUpdateAvailable')).toBeFalsy()
   })
 

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -266,6 +266,12 @@ export const DynamicConfigs = {
       },
     },
   },
+  [StatsigDynamicConfigs.COINBASE_PAY_APP_ID]: {
+    configName: StatsigDynamicConfigs.COINBASE_PAY_APP_ID,
+    defaultValues: {
+      appId: '',
+    },
+  },
 } satisfies {
   [key in StatsigDynamicConfigs | StatsigMultiNetworkDynamicConfig]: {
     configName: key

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -8,6 +8,7 @@ export enum StatsigDynamicConfigs {
   NFT_CELEBRATION_CONFIG = 'nft_celebration_config',
   EARN_STABLECOIN_CONFIG = 'earn_stablecoin_config',
   APP_CONFIG = 'app_config',
+  COINBASE_PAY_APP_ID = 'coinbase_pay_app_id',
 }
 
 // Separating into different enum from StatsigDynamicConfigs to allow for more strict typing


### PR DESCRIPTION
Previously we relied on getting an appId value from Firebase in order to gate CB Pay being available; this moves it over to Statsig.